### PR TITLE
21.08 support for AWS Examples

### DIFF
--- a/terraform/aws/iglu_server/default/README.md
+++ b/terraform/aws/iglu_server/default/README.md
@@ -16,9 +16,9 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iglu_lb"></a> [iglu\_lb](#module\_iglu\_lb) | snowplow-devops/alb/aws | 0.1.1 |
-| <a name="module_iglu_rds"></a> [iglu\_rds](#module\_iglu\_rds) | snowplow-devops/rds/aws | 0.1.3 |
-| <a name="module_iglu_server"></a> [iglu\_server](#module\_iglu\_server) | snowplow-devops/iglu-server-ec2/aws | 0.1.0 |
+| <a name="module_iglu_lb"></a> [iglu\_lb](#module\_iglu\_lb) | snowplow-devops/alb/aws | 0.1.2 |
+| <a name="module_iglu_rds"></a> [iglu\_rds](#module\_iglu\_rds) | snowplow-devops/rds/aws | 0.1.4 |
+| <a name="module_iglu_server"></a> [iglu\_server](#module\_iglu\_server) | snowplow-devops/iglu-server-ec2/aws | 0.2.0 |
 
 ## Resources
 
@@ -39,6 +39,8 @@
 | <a name="input_ssh_ip_allowlist"></a> [ssh\_ip\_allowlist](#input\_ssh\_ip\_allowlist) | The list of CIDR ranges to allow SSH traffic from | `list(any)` | n/a | yes |
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | The SSH public key to use for the deployment | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC to deploy the components within | `string` | n/a | yes |
+| <a name="input_cloudwatch_logs_enabled"></a> [cloudwatch\_logs\_enabled](#input\_cloudwatch\_logs\_enabled) | Whether application logs should be reported to CloudWatch | `bool` | `true` | no |
+| <a name="input_cloudwatch_logs_retention_days"></a> [cloudwatch\_logs\_retention\_days](#input\_cloudwatch\_logs\_retention\_days) | The length of time in days to retain logs for | `number` | `7` | no |
 | <a name="input_iam_permissions_boundary"></a> [iam\_permissions\_boundary](#input\_iam\_permissions\_boundary) | The permissions boundary ARN to set on IAM roles created | `string` | `""` | no |
 | <a name="input_ssl_information"></a> [ssl\_information](#input\_ssl\_information) | The ARN of an Amazon Certificate Manager certificate to bind to the load balancer | <pre>object({<br>    enabled         = bool<br>    certificate_arn = string<br>  })</pre> | <pre>{<br>  "certificate_arn": "",<br>  "enabled": false<br>}</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | The tags to append to the resources in this module | `map(string)` | `{}` | no |

--- a/terraform/aws/iglu_server/default/main.tf
+++ b/terraform/aws/iglu_server/default/main.tf
@@ -36,7 +36,7 @@ module "iglu_lb" {
 
 module "iglu_server" {
   source  = "snowplow-devops/iglu-server-ec2/aws"
-  version = "0.1.1"
+  version = "0.2.0"
 
   name                 = "${var.prefix}-iglu-server"
   vpc_id               = var.vpc_id

--- a/terraform/aws/iglu_server/default/variables.tf
+++ b/terraform/aws/iglu_server/default/variables.tf
@@ -82,8 +82,8 @@ variable "tags" {
 }
 
 variable "cloudwatch_logs_enabled" {
-  description = "Whether application logs should be reported to CloudWatch; by default they are only on the server"
-  default     = false
+  description = "Whether application logs should be reported to CloudWatch"
+  default     = true
   type        = bool
 }
 

--- a/terraform/aws/iglu_server/secure/README.md
+++ b/terraform/aws/iglu_server/secure/README.md
@@ -16,9 +16,9 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iglu_lb"></a> [iglu\_lb](#module\_iglu\_lb) | snowplow-devops/alb/aws | 0.1.1 |
-| <a name="module_iglu_rds"></a> [iglu\_rds](#module\_iglu\_rds) | snowplow-devops/rds/aws | 0.1.3 |
-| <a name="module_iglu_server"></a> [iglu\_server](#module\_iglu\_server) | snowplow-devops/iglu-server-ec2/aws | 0.1.0 |
+| <a name="module_iglu_lb"></a> [iglu\_lb](#module\_iglu\_lb) | snowplow-devops/alb/aws | 0.1.2 |
+| <a name="module_iglu_rds"></a> [iglu\_rds](#module\_iglu\_rds) | snowplow-devops/rds/aws | 0.1.4 |
+| <a name="module_iglu_server"></a> [iglu\_server](#module\_iglu\_server) | snowplow-devops/iglu-server-ec2/aws | 0.2.0 |
 
 ## Resources
 
@@ -40,6 +40,8 @@
 | <a name="input_ssh_ip_allowlist"></a> [ssh\_ip\_allowlist](#input\_ssh\_ip\_allowlist) | The list of CIDR ranges to allow SSH traffic from | `list(any)` | n/a | yes |
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | The SSH public key to use for the deployment | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC to deploy the components within | `string` | n/a | yes |
+| <a name="input_cloudwatch_logs_enabled"></a> [cloudwatch\_logs\_enabled](#input\_cloudwatch\_logs\_enabled) | Whether application logs should be reported to CloudWatch | `bool` | `true` | no |
+| <a name="input_cloudwatch_logs_retention_days"></a> [cloudwatch\_logs\_retention\_days](#input\_cloudwatch\_logs\_retention\_days) | The length of time in days to retain logs for | `number` | `7` | no |
 | <a name="input_iam_permissions_boundary"></a> [iam\_permissions\_boundary](#input\_iam\_permissions\_boundary) | The permissions boundary ARN to set on IAM roles created | `string` | `""` | no |
 | <a name="input_ssl_information"></a> [ssl\_information](#input\_ssl\_information) | The ARN of an Amazon Certificate Manager certificate to bind to the load balancer | <pre>object({<br>    enabled         = bool<br>    certificate_arn = string<br>  })</pre> | <pre>{<br>  "certificate_arn": "",<br>  "enabled": false<br>}</pre> | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | The tags to append to the resources in this module | `map(string)` | `{}` | no |

--- a/terraform/aws/iglu_server/secure/main.tf
+++ b/terraform/aws/iglu_server/secure/main.tf
@@ -36,7 +36,7 @@ module "iglu_lb" {
 
 module "iglu_server" {
   source  = "snowplow-devops/iglu-server-ec2/aws"
-  version = "0.1.1"
+  version = "0.2.0"
 
   name                 = "${var.prefix}-iglu-server"
   vpc_id               = var.vpc_id

--- a/terraform/aws/iglu_server/secure/variables.tf
+++ b/terraform/aws/iglu_server/secure/variables.tf
@@ -87,8 +87,8 @@ variable "tags" {
 }
 
 variable "cloudwatch_logs_enabled" {
-  description = "Whether application logs should be reported to CloudWatch; by default they are only on the server"
-  default     = false
+  description = "Whether application logs should be reported to CloudWatch"
+  default     = true
   type        = bool
 }
 

--- a/terraform/aws/pipeline/default/README.md
+++ b/terraform/aws/pipeline/default/README.md
@@ -16,20 +16,20 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_bad_1_stream"></a> [bad\_1\_stream](#module\_bad\_1\_stream) | snowplow-devops/kinesis-stream/aws | 0.1.0 |
-| <a name="module_bad_2_stream"></a> [bad\_2\_stream](#module\_bad\_2\_stream) | snowplow-devops/kinesis-stream/aws | 0.1.0 |
-| <a name="module_collector_kinesis"></a> [collector\_kinesis](#module\_collector\_kinesis) | snowplow-devops/collector-kinesis-ec2/aws | 0.1.1 |
-| <a name="module_collector_lb"></a> [collector\_lb](#module\_collector\_lb) | snowplow-devops/alb/aws | 0.1.1 |
-| <a name="module_enrich_kinesis"></a> [enrich\_kinesis](#module\_enrich\_kinesis) | snowplow-devops/enrich-kinesis-ec2/aws | 0.1.2 |
-| <a name="module_enriched_stream"></a> [enriched\_stream](#module\_enriched\_stream) | snowplow-devops/kinesis-stream/aws | 0.1.0 |
-| <a name="module_pipeline_rds"></a> [pipeline\_rds](#module\_pipeline\_rds) | snowplow-devops/rds/aws | 0.1.3 |
-| <a name="module_postgres_loader_bad"></a> [postgres\_loader\_bad](#module\_postgres\_loader\_bad) | snowplow-devops/postgres-loader-kinesis-ec2/aws | 0.1.0 |
-| <a name="module_postgres_loader_enriched"></a> [postgres\_loader\_enriched](#module\_postgres\_loader\_enriched) | snowplow-devops/postgres-loader-kinesis-ec2/aws | 0.1.0 |
-| <a name="module_raw_stream"></a> [raw\_stream](#module\_raw\_stream) | snowplow-devops/kinesis-stream/aws | 0.1.0 |
-| <a name="module_s3_loader_bad"></a> [s3\_loader\_bad](#module\_s3\_loader\_bad) | snowplow-devops/s3-loader-kinesis-ec2/aws | 0.1.2 |
-| <a name="module_s3_loader_enriched"></a> [s3\_loader\_enriched](#module\_s3\_loader\_enriched) | snowplow-devops/s3-loader-kinesis-ec2/aws | 0.1.2 |
-| <a name="module_s3_loader_raw"></a> [s3\_loader\_raw](#module\_s3\_loader\_raw) | snowplow-devops/s3-loader-kinesis-ec2/aws | 0.1.2 |
-| <a name="module_s3_pipeline_bucket"></a> [s3\_pipeline\_bucket](#module\_s3\_pipeline\_bucket) | snowplow-devops/s3-bucket/aws | 0.1.0 |
+| <a name="module_bad_1_stream"></a> [bad\_1\_stream](#module\_bad\_1\_stream) | snowplow-devops/kinesis-stream/aws | 0.1.1 |
+| <a name="module_bad_2_stream"></a> [bad\_2\_stream](#module\_bad\_2\_stream) | snowplow-devops/kinesis-stream/aws | 0.1.1 |
+| <a name="module_collector_kinesis"></a> [collector\_kinesis](#module\_collector\_kinesis) | snowplow-devops/collector-kinesis-ec2/aws | 0.2.0 |
+| <a name="module_collector_lb"></a> [collector\_lb](#module\_collector\_lb) | snowplow-devops/alb/aws | 0.1.2 |
+| <a name="module_enrich_kinesis"></a> [enrich\_kinesis](#module\_enrich\_kinesis) | snowplow-devops/enrich-kinesis-ec2/aws | 0.2.0 |
+| <a name="module_enriched_stream"></a> [enriched\_stream](#module\_enriched\_stream) | snowplow-devops/kinesis-stream/aws | 0.1.1 |
+| <a name="module_pipeline_rds"></a> [pipeline\_rds](#module\_pipeline\_rds) | snowplow-devops/rds/aws | 0.1.4 |
+| <a name="module_postgres_loader_bad"></a> [postgres\_loader\_bad](#module\_postgres\_loader\_bad) | snowplow-devops/postgres-loader-kinesis-ec2/aws | 0.2.0 |
+| <a name="module_postgres_loader_enriched"></a> [postgres\_loader\_enriched](#module\_postgres\_loader\_enriched) | snowplow-devops/postgres-loader-kinesis-ec2/aws | 0.2.0 |
+| <a name="module_raw_stream"></a> [raw\_stream](#module\_raw\_stream) | snowplow-devops/kinesis-stream/aws | 0.1.1 |
+| <a name="module_s3_loader_bad"></a> [s3\_loader\_bad](#module\_s3\_loader\_bad) | snowplow-devops/s3-loader-kinesis-ec2/aws | 0.2.0 |
+| <a name="module_s3_loader_enriched"></a> [s3\_loader\_enriched](#module\_s3\_loader\_enriched) | snowplow-devops/s3-loader-kinesis-ec2/aws | 0.2.0 |
+| <a name="module_s3_loader_raw"></a> [s3\_loader\_raw](#module\_s3\_loader\_raw) | snowplow-devops/s3-loader-kinesis-ec2/aws | 0.2.0 |
+| <a name="module_s3_pipeline_bucket"></a> [s3\_pipeline\_bucket](#module\_s3\_pipeline\_bucket) | snowplow-devops/s3-bucket/aws | 0.1.1 |
 
 ## Resources
 
@@ -52,10 +52,12 @@
 | <a name="input_ssh_ip_allowlist"></a> [ssh\_ip\_allowlist](#input\_ssh\_ip\_allowlist) | The list of CIDR ranges to allow SSH traffic from | `list(any)` | n/a | yes |
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | The SSH public key to use for the deployment | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC to deploy the components within | `string` | n/a | yes |
+| <a name="input_cloudwatch_logs_enabled"></a> [cloudwatch\_logs\_enabled](#input\_cloudwatch\_logs\_enabled) | Whether application logs should be reported to CloudWatch | `bool` | `true` | no |
+| <a name="input_cloudwatch_logs_retention_days"></a> [cloudwatch\_logs\_retention\_days](#input\_cloudwatch\_logs\_retention\_days) | The length of time in days to retain logs for | `number` | `7` | no |
 | <a name="input_iam_permissions_boundary"></a> [iam\_permissions\_boundary](#input\_iam\_permissions\_boundary) | The permissions boundary ARN to set on IAM roles created | `string` | `""` | no |
 | <a name="input_pipeline_db_ip_allowlist"></a> [pipeline\_db\_ip\_allowlist](#input\_pipeline\_db\_ip\_allowlist) | An optional list of CIDR ranges to allow traffic from | `list(any)` | `[]` | no |
 | <a name="input_pipeline_db_publicly_accessible"></a> [pipeline\_db\_publicly\_accessible](#input\_pipeline\_db\_publicly\_accessible) | Whether to make the Postgres RDS instance accessible over the internet | `bool` | `false` | no |
-| <a name="input_pipeline_kcl_write_max_capacity"></a> [pipeline\_kcl\_write\_max\_capacity](#input\_pipeline\_kcl\_write\_max\_capacity) | Increasing this is important to increase throughput | `number` | `50` | no |
+| <a name="input_pipeline_kcl_write_max_capacity"></a> [pipeline\_kcl\_write\_max\_capacity](#input\_pipeline\_kcl\_write\_max\_capacity) | Increasing this is important to increase throughput at very high pipeline volumes | `number` | `50` | no |
 | <a name="input_s3_bucket_deploy"></a> [s3\_bucket\_deploy](#input\_s3\_bucket\_deploy) | Whether this module should create a new bucket with the specified name - if the bucket already exists set this to false | `bool` | `true` | no |
 | <a name="input_s3_bucket_object_prefix"></a> [s3\_bucket\_object\_prefix](#input\_s3\_bucket\_object\_prefix) | An optional prefix under which Snowplow data will be saved (Note: your prefix must end with a trailing '/') | `string` | `""` | no |
 | <a name="input_ssl_information"></a> [ssl\_information](#input\_ssl\_information) | The ARN of an Amazon Certificate Manager certificate to bind to the load balancer | <pre>object({<br>    enabled         = bool<br>    certificate_arn = string<br>  })</pre> | <pre>{<br>  "certificate_arn": "",<br>  "enabled": false<br>}</pre> | no |

--- a/terraform/aws/pipeline/default/main.tf
+++ b/terraform/aws/pipeline/default/main.tf
@@ -82,7 +82,7 @@ module "collector_lb" {
 
 module "collector_kinesis" {
   source  = "snowplow-devops/collector-kinesis-ec2/aws"
-  version = "0.1.2"
+  version = "0.2.0"
 
   name               = "${var.prefix}-collector-server"
   vpc_id             = var.vpc_id
@@ -110,7 +110,7 @@ module "collector_kinesis" {
 # 3. Deploy Enrichment
 module "enrich_kinesis" {
   source  = "snowplow-devops/enrich-kinesis-ec2/aws"
-  version = "0.1.4"
+  version = "0.2.0"
 
   name                 = "${var.prefix}-enrich-server"
   vpc_id               = var.vpc_id
@@ -158,7 +158,7 @@ module "pipeline_rds" {
 
 module "postgres_loader_enriched" {
   source  = "snowplow-devops/postgres-loader-kinesis-ec2/aws"
-  version = "0.1.1"
+  version = "0.2.0"
 
   name       = "${var.prefix}-postgres-loader-enriched-server"
   vpc_id     = var.vpc_id
@@ -196,7 +196,7 @@ module "postgres_loader_enriched" {
 
 module "postgres_loader_bad" {
   source  = "snowplow-devops/postgres-loader-kinesis-ec2/aws"
-  version = "0.1.1"
+  version = "0.2.0"
 
   name       = "${var.prefix}-postgres-loader-bad-server"
   vpc_id     = var.vpc_id
@@ -235,7 +235,7 @@ module "postgres_loader_bad" {
 # 5. Save raw, enriched and bad data to Amazon S3
 module "s3_loader_raw" {
   source  = "snowplow-devops/s3-loader-kinesis-ec2/aws"
-  version = "0.1.3"
+  version = "0.2.0"
 
   name             = "${var.prefix}-s3-loader-raw-server"
   vpc_id           = var.vpc_id
@@ -263,7 +263,7 @@ module "s3_loader_raw" {
 
 module "s3_loader_bad" {
   source  = "snowplow-devops/s3-loader-kinesis-ec2/aws"
-  version = "0.1.3"
+  version = "0.2.0"
 
   name             = "${var.prefix}-s3-loader-bad-server"
   vpc_id           = var.vpc_id
@@ -291,7 +291,7 @@ module "s3_loader_bad" {
 
 module "s3_loader_enriched" {
   source  = "snowplow-devops/s3-loader-kinesis-ec2/aws"
-  version = "0.1.3"
+  version = "0.2.0"
 
   name             = "${var.prefix}-s3-loader-enriched-server"
   vpc_id           = var.vpc_id

--- a/terraform/aws/pipeline/default/terraform.tfvars
+++ b/terraform/aws/pipeline/default/terraform.tfvars
@@ -49,10 +49,7 @@ pipeline_db_password = "Hell0W0rld!2"
 pipeline_db_publicly_accessible = true
 pipeline_db_ip_allowlist        = ["999.999.999.999/32", "888.888.888.888/32"]
 
-# Note: the postgres loader can be limited by KCL throughput - increasing this is crucial for anything over 50 RPS.
-#       There is roughly a 1:1 relationship between this value and Rows per second (RPS).
-#
-# While this limit is most important to the Postgres Loader this write capacity will be applied to all consumers.
+# Controls the write throughput of the KCL tables maintained by the various consumers deployed
 pipeline_kcl_write_max_capacity = 50
 
 # See for more information: https://registry.terraform.io/modules/snowplow-devops/collector-kinesis-ec2/aws/latest#telemetry

--- a/terraform/aws/pipeline/default/variables.tf
+++ b/terraform/aws/pipeline/default/variables.tf
@@ -80,7 +80,7 @@ variable "pipeline_db_ip_allowlist" {
 }
 
 variable "pipeline_kcl_write_max_capacity" {
-  description = "Increasing this is important to increase throughput"
+  description = "Increasing this is important to increase throughput at very high pipeline volumes"
   type        = number
   default     = 50
 }
@@ -122,8 +122,8 @@ variable "tags" {
 }
 
 variable "cloudwatch_logs_enabled" {
-  description = "Whether application logs should be reported to CloudWatch; by default they are only on the server"
-  default     = false
+  description = "Whether application logs should be reported to CloudWatch"
+  default     = true
   type        = bool
 }
 

--- a/terraform/aws/pipeline/secure/README.md
+++ b/terraform/aws/pipeline/secure/README.md
@@ -16,20 +16,20 @@
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_bad_1_stream"></a> [bad\_1\_stream](#module\_bad\_1\_stream) | snowplow-devops/kinesis-stream/aws | 0.1.0 |
-| <a name="module_bad_2_stream"></a> [bad\_2\_stream](#module\_bad\_2\_stream) | snowplow-devops/kinesis-stream/aws | 0.1.0 |
-| <a name="module_collector_kinesis"></a> [collector\_kinesis](#module\_collector\_kinesis) | snowplow-devops/collector-kinesis-ec2/aws | 0.1.1 |
-| <a name="module_collector_lb"></a> [collector\_lb](#module\_collector\_lb) | snowplow-devops/alb/aws | 0.1.1 |
-| <a name="module_enrich_kinesis"></a> [enrich\_kinesis](#module\_enrich\_kinesis) | snowplow-devops/enrich-kinesis-ec2/aws | 0.1.2 |
-| <a name="module_enriched_stream"></a> [enriched\_stream](#module\_enriched\_stream) | snowplow-devops/kinesis-stream/aws | 0.1.0 |
-| <a name="module_pipeline_rds"></a> [pipeline\_rds](#module\_pipeline\_rds) | snowplow-devops/rds/aws | 0.1.3 |
-| <a name="module_postgres_loader_bad"></a> [postgres\_loader\_bad](#module\_postgres\_loader\_bad) | snowplow-devops/postgres-loader-kinesis-ec2/aws | 0.1.0 |
-| <a name="module_postgres_loader_enriched"></a> [postgres\_loader\_enriched](#module\_postgres\_loader\_enriched) | snowplow-devops/postgres-loader-kinesis-ec2/aws | 0.1.0 |
-| <a name="module_raw_stream"></a> [raw\_stream](#module\_raw\_stream) | snowplow-devops/kinesis-stream/aws | 0.1.0 |
-| <a name="module_s3_loader_bad"></a> [s3\_loader\_bad](#module\_s3\_loader\_bad) | snowplow-devops/s3-loader-kinesis-ec2/aws | 0.1.2 |
-| <a name="module_s3_loader_enriched"></a> [s3\_loader\_enriched](#module\_s3\_loader\_enriched) | snowplow-devops/s3-loader-kinesis-ec2/aws | 0.1.2 |
-| <a name="module_s3_loader_raw"></a> [s3\_loader\_raw](#module\_s3\_loader\_raw) | snowplow-devops/s3-loader-kinesis-ec2/aws | 0.1.2 |
-| <a name="module_s3_pipeline_bucket"></a> [s3\_pipeline\_bucket](#module\_s3\_pipeline\_bucket) | snowplow-devops/s3-bucket/aws | 0.1.0 |
+| <a name="module_bad_1_stream"></a> [bad\_1\_stream](#module\_bad\_1\_stream) | snowplow-devops/kinesis-stream/aws | 0.1.1 |
+| <a name="module_bad_2_stream"></a> [bad\_2\_stream](#module\_bad\_2\_stream) | snowplow-devops/kinesis-stream/aws | 0.1.1 |
+| <a name="module_collector_kinesis"></a> [collector\_kinesis](#module\_collector\_kinesis) | snowplow-devops/collector-kinesis-ec2/aws | 0.2.0 |
+| <a name="module_collector_lb"></a> [collector\_lb](#module\_collector\_lb) | snowplow-devops/alb/aws | 0.1.2 |
+| <a name="module_enrich_kinesis"></a> [enrich\_kinesis](#module\_enrich\_kinesis) | snowplow-devops/enrich-kinesis-ec2/aws | 0.2.0 |
+| <a name="module_enriched_stream"></a> [enriched\_stream](#module\_enriched\_stream) | snowplow-devops/kinesis-stream/aws | 0.1.1 |
+| <a name="module_pipeline_rds"></a> [pipeline\_rds](#module\_pipeline\_rds) | snowplow-devops/rds/aws | 0.1.4 |
+| <a name="module_postgres_loader_bad"></a> [postgres\_loader\_bad](#module\_postgres\_loader\_bad) | snowplow-devops/postgres-loader-kinesis-ec2/aws | 0.2.0 |
+| <a name="module_postgres_loader_enriched"></a> [postgres\_loader\_enriched](#module\_postgres\_loader\_enriched) | snowplow-devops/postgres-loader-kinesis-ec2/aws | 0.2.0 |
+| <a name="module_raw_stream"></a> [raw\_stream](#module\_raw\_stream) | snowplow-devops/kinesis-stream/aws | 0.1.1 |
+| <a name="module_s3_loader_bad"></a> [s3\_loader\_bad](#module\_s3\_loader\_bad) | snowplow-devops/s3-loader-kinesis-ec2/aws | 0.2.0 |
+| <a name="module_s3_loader_enriched"></a> [s3\_loader\_enriched](#module\_s3\_loader\_enriched) | snowplow-devops/s3-loader-kinesis-ec2/aws | 0.2.0 |
+| <a name="module_s3_loader_raw"></a> [s3\_loader\_raw](#module\_s3\_loader\_raw) | snowplow-devops/s3-loader-kinesis-ec2/aws | 0.2.0 |
+| <a name="module_s3_pipeline_bucket"></a> [s3\_pipeline\_bucket](#module\_s3\_pipeline\_bucket) | snowplow-devops/s3-bucket/aws | 0.1.1 |
 
 ## Resources
 
@@ -53,9 +53,11 @@
 | <a name="input_ssh_ip_allowlist"></a> [ssh\_ip\_allowlist](#input\_ssh\_ip\_allowlist) | The list of CIDR ranges to allow SSH traffic from | `list(any)` | n/a | yes |
 | <a name="input_ssh_public_key"></a> [ssh\_public\_key](#input\_ssh\_public\_key) | The SSH public key to use for the deployment | `string` | n/a | yes |
 | <a name="input_vpc_id"></a> [vpc\_id](#input\_vpc\_id) | The VPC to deploy the components within | `string` | n/a | yes |
+| <a name="input_cloudwatch_logs_enabled"></a> [cloudwatch\_logs\_enabled](#input\_cloudwatch\_logs\_enabled) | Whether application logs should be reported to CloudWatch | `bool` | `true` | no |
+| <a name="input_cloudwatch_logs_retention_days"></a> [cloudwatch\_logs\_retention\_days](#input\_cloudwatch\_logs\_retention\_days) | The length of time in days to retain logs for | `number` | `7` | no |
 | <a name="input_iam_permissions_boundary"></a> [iam\_permissions\_boundary](#input\_iam\_permissions\_boundary) | The permissions boundary ARN to set on IAM roles created | `string` | `""` | no |
 | <a name="input_pipeline_db_ip_allowlist"></a> [pipeline\_db\_ip\_allowlist](#input\_pipeline\_db\_ip\_allowlist) | An optional list of CIDR ranges to allow traffic from | `list(any)` | `[]` | no |
-| <a name="input_pipeline_kcl_write_max_capacity"></a> [pipeline\_kcl\_write\_max\_capacity](#input\_pipeline\_kcl\_write\_max\_capacity) | Increasing this is important to increase throughput | `number` | `50` | no |
+| <a name="input_pipeline_kcl_write_max_capacity"></a> [pipeline\_kcl\_write\_max\_capacity](#input\_pipeline\_kcl\_write\_max\_capacity) | Increasing this is important to increase throughput at very high pipeline volumes | `number` | `50` | no |
 | <a name="input_s3_bucket_deploy"></a> [s3\_bucket\_deploy](#input\_s3\_bucket\_deploy) | Whether this module should create a new bucket with the specified name - if the bucket already exists set this to false | `bool` | `true` | no |
 | <a name="input_s3_bucket_object_prefix"></a> [s3\_bucket\_object\_prefix](#input\_s3\_bucket\_object\_prefix) | An optional prefix under which Snowplow data will be saved (Note: your prefix must end with a trailing '/') | `string` | `""` | no |
 | <a name="input_ssl_information"></a> [ssl\_information](#input\_ssl\_information) | The ARN of an Amazon Certificate Manager certificate to bind to the load balancer | <pre>object({<br>    enabled         = bool<br>    certificate_arn = string<br>  })</pre> | <pre>{<br>  "certificate_arn": "",<br>  "enabled": false<br>}</pre> | no |

--- a/terraform/aws/pipeline/secure/main.tf
+++ b/terraform/aws/pipeline/secure/main.tf
@@ -82,7 +82,7 @@ module "collector_lb" {
 
 module "collector_kinesis" {
   source  = "snowplow-devops/collector-kinesis-ec2/aws"
-  version = "0.1.2"
+  version = "0.2.0"
 
   name               = "${var.prefix}-collector-server"
   vpc_id             = var.vpc_id
@@ -112,7 +112,7 @@ module "collector_kinesis" {
 # 3. Deploy Enrichment
 module "enrich_kinesis" {
   source  = "snowplow-devops/enrich-kinesis-ec2/aws"
-  version = "0.1.4"
+  version = "0.2.0"
 
   name                 = "${var.prefix}-enrich-server"
   vpc_id               = var.vpc_id
@@ -162,7 +162,7 @@ module "pipeline_rds" {
 
 module "postgres_loader_enriched" {
   source  = "snowplow-devops/postgres-loader-kinesis-ec2/aws"
-  version = "0.1.1"
+  version = "0.2.0"
 
   name       = "${var.prefix}-postgres-loader-enriched-server"
   vpc_id     = var.vpc_id
@@ -202,7 +202,7 @@ module "postgres_loader_enriched" {
 
 module "postgres_loader_bad" {
   source  = "snowplow-devops/postgres-loader-kinesis-ec2/aws"
-  version = "0.1.1"
+  version = "0.2.0"
 
   name       = "${var.prefix}-postgres-loader-bad-server"
   vpc_id     = var.vpc_id
@@ -243,7 +243,7 @@ module "postgres_loader_bad" {
 # 5. Save raw, enriched and bad data to Amazon S3
 module "s3_loader_raw" {
   source  = "snowplow-devops/s3-loader-kinesis-ec2/aws"
-  version = "0.1.3"
+  version = "0.2.0"
 
   name             = "${var.prefix}-s3-loader-raw-server"
   vpc_id           = var.vpc_id
@@ -273,7 +273,7 @@ module "s3_loader_raw" {
 
 module "s3_loader_bad" {
   source  = "snowplow-devops/s3-loader-kinesis-ec2/aws"
-  version = "0.1.3"
+  version = "0.2.0"
 
   name             = "${var.prefix}-s3-loader-bad-server"
   vpc_id           = var.vpc_id
@@ -303,7 +303,7 @@ module "s3_loader_bad" {
 
 module "s3_loader_enriched" {
   source  = "snowplow-devops/s3-loader-kinesis-ec2/aws"
-  version = "0.1.3"
+  version = "0.2.0"
 
   name             = "${var.prefix}-s3-loader-enriched-server"
   vpc_id           = var.vpc_id

--- a/terraform/aws/pipeline/secure/terraform.tfvars
+++ b/terraform/aws/pipeline/secure/terraform.tfvars
@@ -50,10 +50,7 @@ pipeline_db_password = "Hell0W0rld!2"
 # Note: these IP ranges will need to be internal to your VPC like from a Bastion Host
 pipeline_db_ip_allowlist = ["999.999.999.999/32", "888.888.888.888/32"]
 
-# Note: the postgres loader can be limited by KCL throughput - increasing this is crucial for anything over 50 RPS.
-#       There is roughly a 1:1 relationship between this value and Rows per second (RPS).
-#
-# While this limit is most important to the Postgres Loader this write capacity will be applied to all consumers.
+# Controls the write throughput of the KCL tables maintained by the various consumers deployed
 pipeline_kcl_write_max_capacity = 50
 
 # See for more information: https://registry.terraform.io/modules/snowplow-devops/collector-kinesis-ec2/aws/latest#telemetry

--- a/terraform/aws/pipeline/secure/variables.tf
+++ b/terraform/aws/pipeline/secure/variables.tf
@@ -79,7 +79,7 @@ variable "pipeline_db_ip_allowlist" {
 }
 
 variable "pipeline_kcl_write_max_capacity" {
-  description = "Increasing this is important to increase throughput"
+  description = "Increasing this is important to increase throughput at very high pipeline volumes"
   type        = number
   default     = 50
 }
@@ -121,8 +121,8 @@ variable "tags" {
 }
 
 variable "cloudwatch_logs_enabled" {
-  description = "Whether application logs should be reported to CloudWatch; by default they are only on the server"
-  default     = false
+  description = "Whether application logs should be reported to CloudWatch"
+  default     = true
   type        = bool
 }
 


### PR DESCRIPTION
Bumps all associated modules to the 21.08 pinned versions and switches to CloudWatch logging being on by default in the variables as well.

It also removes references to KCL needing to be bumped for throughput - the new Postgres Loader can handle 180 RPS with a single write unit now.  Still important at the very upper end of the scale but with 50 write units users could scale to thousands of RPS now.