### PR TITLE
Release/25.06

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,6 @@ Licensed under the [Snowplow Limited Use License Agreement][license]. _(If you a
 [discourse]: http://discourse.snowplow.io/
 
 [release]: https://github.com/snowplow/snowplow/releases
-[release-badge]: https://img.shields.io/badge/Snowplow-25.01%20%28Patch.1%29-6638b8
+[release-badge]: https://img.shields.io/badge/Snowplow-25.06-6638b8
 
 [tf-docs]: https://github.com/terraform-docs/terraform-docs

--- a/terraform/gcp/iglu_server/default/README.md
+++ b/terraform/gcp/iglu_server/default/README.md
@@ -14,9 +14,9 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iglu_db"></a> [iglu\_db](#module\_iglu\_db) | snowplow-devops/cloud-sql/google | 0.3.0 |
+| <a name="module_iglu_db"></a> [iglu\_db](#module\_iglu\_db) | snowplow-devops/cloud-sql/google | 0.4.1 |
 | <a name="module_iglu_lb"></a> [iglu\_lb](#module\_iglu\_lb) | snowplow-devops/lb/google | 0.3.0 |
-| <a name="module_iglu_server"></a> [iglu\_server](#module\_iglu\_server) | snowplow-devops/iglu-server-ce/google | 0.5.0 |
+| <a name="module_iglu_server"></a> [iglu\_server](#module\_iglu\_server) | snowplow-devops/iglu-server-ce/google | 0.6.0 |
 
 ## Resources
 
@@ -38,8 +38,8 @@ No resources.
 | <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | The name of the sub-network to deploy within | `string` | n/a | yes |
 | <a name="input_accept_limited_use_license"></a> [accept\_limited\_use\_license](#input\_accept\_limited\_use\_license) | Acceptance of the SLULA terms (https://docs.snowplow.io/limited-use-license-1.0/) | `bool` | `false` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | The labels to append to the resources in this module | `map(string)` | `{}` | no |
-| <a name="input_ssh_key_pairs"></a> [ssh\_key\_pairs](#input\_ssh\_key\_pairs) | The list of SSH key-pairs to add to the servers | <pre>list(object({<br>    user_name  = string<br>    public_key = string<br>  }))</pre> | `[]` | no |
-| <a name="input_ssl_information"></a> [ssl\_information](#input\_ssl\_information) | The ID of an Google Managed certificate to bind to the load balancer | <pre>object({<br>    enabled        = bool<br>    certificate_id = string<br>  })</pre> | <pre>{<br>  "certificate_id": "",<br>  "enabled": false<br>}</pre> | no |
+| <a name="input_ssh_key_pairs"></a> [ssh\_key\_pairs](#input\_ssh\_key\_pairs) | The list of SSH key-pairs to add to the servers | <pre>list(object({<br/>    user_name  = string<br/>    public_key = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_ssl_information"></a> [ssl\_information](#input\_ssl\_information) | The ID of an Google Managed certificate to bind to the load balancer | <pre>object({<br/>    enabled        = bool<br/>    certificate_id = string<br/>  })</pre> | <pre>{<br/>  "certificate_id": "",<br/>  "enabled": false<br/>}</pre> | no |
 | <a name="input_telemetry_enabled"></a> [telemetry\_enabled](#input\_telemetry\_enabled) | Whether or not to send telemetry information back to Snowplow Analytics Ltd | `bool` | `true` | no |
 | <a name="input_user_provided_id"></a> [user\_provided\_id](#input\_user\_provided\_id) | An optional unique identifier to identify the telemetry events emitted by this stack | `string` | `""` | no |
 

--- a/terraform/gcp/iglu_server/default/main.tf
+++ b/terraform/gcp/iglu_server/default/main.tf
@@ -5,7 +5,7 @@ provider "google" {
 
 module "iglu_db" {
   source  = "snowplow-devops/cloud-sql/google"
-  version = "0.3.1"
+  version = "0.4.1"
 
   name = "${var.prefix}-iglu-db"
 
@@ -19,7 +19,7 @@ module "iglu_db" {
 
 module "iglu_server" {
   source  = "snowplow-devops/iglu-server-ce/google"
-  version = "0.5.0"
+  version = "0.6.0"
 
   accept_limited_use_license = var.accept_limited_use_license
 

--- a/terraform/gcp/iglu_server/secure/README.md
+++ b/terraform/gcp/iglu_server/secure/README.md
@@ -14,9 +14,9 @@ No providers.
 
 | Name | Source | Version |
 |------|--------|---------|
-| <a name="module_iglu_db"></a> [iglu\_db](#module\_iglu\_db) | snowplow-devops/cloud-sql/google | 0.3.0 |
+| <a name="module_iglu_db"></a> [iglu\_db](#module\_iglu\_db) | snowplow-devops/cloud-sql/google | 0.4.1 |
 | <a name="module_iglu_lb"></a> [iglu\_lb](#module\_iglu\_lb) | snowplow-devops/lb/google | 0.3.0 |
-| <a name="module_iglu_server"></a> [iglu\_server](#module\_iglu\_server) | snowplow-devops/iglu-server-ce/google | 0.5.0 |
+| <a name="module_iglu_server"></a> [iglu\_server](#module\_iglu\_server) | snowplow-devops/iglu-server-ce/google | 0.6.0 |
 
 ## Resources
 
@@ -38,8 +38,8 @@ No resources.
 | <a name="input_subnetwork"></a> [subnetwork](#input\_subnetwork) | The name of the sub-network to deploy within | `string` | n/a | yes |
 | <a name="input_accept_limited_use_license"></a> [accept\_limited\_use\_license](#input\_accept\_limited\_use\_license) | Acceptance of the SLULA terms (https://docs.snowplow.io/limited-use-license-1.0/) | `bool` | `false` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | The labels to append to the resources in this module | `map(string)` | `{}` | no |
-| <a name="input_ssh_key_pairs"></a> [ssh\_key\_pairs](#input\_ssh\_key\_pairs) | The list of SSH key-pairs to add to the servers | <pre>list(object({<br>    user_name  = string<br>    public_key = string<br>  }))</pre> | `[]` | no |
-| <a name="input_ssl_information"></a> [ssl\_information](#input\_ssl\_information) | The ID of an Google Managed certificate to bind to the load balancer | <pre>object({<br>    enabled        = bool<br>    certificate_id = string<br>  })</pre> | <pre>{<br>  "certificate_id": "",<br>  "enabled": false<br>}</pre> | no |
+| <a name="input_ssh_key_pairs"></a> [ssh\_key\_pairs](#input\_ssh\_key\_pairs) | The list of SSH key-pairs to add to the servers | <pre>list(object({<br/>    user_name  = string<br/>    public_key = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_ssl_information"></a> [ssl\_information](#input\_ssl\_information) | The ID of an Google Managed certificate to bind to the load balancer | <pre>object({<br/>    enabled        = bool<br/>    certificate_id = string<br/>  })</pre> | <pre>{<br/>  "certificate_id": "",<br/>  "enabled": false<br/>}</pre> | no |
 | <a name="input_telemetry_enabled"></a> [telemetry\_enabled](#input\_telemetry\_enabled) | Whether or not to send telemetry information back to Snowplow Analytics Ltd | `bool` | `true` | no |
 | <a name="input_user_provided_id"></a> [user\_provided\_id](#input\_user\_provided\_id) | An optional unique identifier to identify the telemetry events emitted by this stack | `string` | `""` | no |
 

--- a/terraform/gcp/iglu_server/secure/main.tf
+++ b/terraform/gcp/iglu_server/secure/main.tf
@@ -5,7 +5,7 @@ provider "google" {
 
 module "iglu_db" {
   source  = "snowplow-devops/cloud-sql/google"
-  version = "0.3.1"
+  version = "0.4.1"
 
   name = "${var.prefix}-iglu-db"
 
@@ -19,7 +19,7 @@ module "iglu_db" {
 
 module "iglu_server" {
   source  = "snowplow-devops/iglu-server-ce/google"
-  version = "0.5.0"
+  version = "0.6.0"
 
   accept_limited_use_license = var.accept_limited_use_license
 

--- a/terraform/gcp/pipeline/default/README.md
+++ b/terraform/gcp/pipeline/default/README.md
@@ -3,29 +3,29 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.90 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3.90 |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.14.1 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_bad_1_topic"></a> [bad\_1\_topic](#module\_bad\_1\_topic) | snowplow-devops/pubsub-topic/google | 0.3.0 |
-| <a name="module_bigquery_loader"></a> [bigquery\_loader](#module\_bigquery\_loader) | snowplow-devops/bigquery-loader-pubsub-ce/google | 0.3.0 |
+| <a name="module_bigquery_loader"></a> [bigquery\_loader](#module\_bigquery\_loader) | snowplow-devops/bigquery-loader-pubsub-ce/google | 0.4.0 |
 | <a name="module_bq_bad_rows_topic"></a> [bq\_bad\_rows\_topic](#module\_bq\_bad\_rows\_topic) | snowplow-devops/pubsub-topic/google | 0.3.0 |
 | <a name="module_collector_lb"></a> [collector\_lb](#module\_collector\_lb) | snowplow-devops/lb/google | 0.3.0 |
-| <a name="module_collector_pubsub"></a> [collector\_pubsub](#module\_collector\_pubsub) | snowplow-devops/collector-pubsub-ce/google | 0.5.0 |
-| <a name="module_enrich_pubsub"></a> [enrich\_pubsub](#module\_enrich\_pubsub) | snowplow-devops/enrich-pubsub-ce/google | 0.3.0 |
+| <a name="module_collector_pubsub"></a> [collector\_pubsub](#module\_collector\_pubsub) | snowplow-devops/collector-pubsub-ce/google | 0.6.0 |
+| <a name="module_enrich_pubsub"></a> [enrich\_pubsub](#module\_enrich\_pubsub) | snowplow-devops/enrich-pubsub-ce/google | 0.4.0 |
 | <a name="module_enriched_topic"></a> [enriched\_topic](#module\_enriched\_topic) | snowplow-devops/pubsub-topic/google | 0.3.0 |
-| <a name="module_postgres_db"></a> [postgres\_db](#module\_postgres\_db) | snowplow-devops/cloud-sql/google | 0.3.0 |
-| <a name="module_postgres_loader_bad"></a> [postgres\_loader\_bad](#module\_postgres\_loader\_bad) | snowplow-devops/postgres-loader-pubsub-ce/google | 0.4.0 |
-| <a name="module_postgres_loader_enriched"></a> [postgres\_loader\_enriched](#module\_postgres\_loader\_enriched) | snowplow-devops/postgres-loader-pubsub-ce/google | 0.4.0 |
+| <a name="module_postgres_db"></a> [postgres\_db](#module\_postgres\_db) | snowplow-devops/cloud-sql/google | 0.4.1 |
+| <a name="module_postgres_loader_bad"></a> [postgres\_loader\_bad](#module\_postgres\_loader\_bad) | snowplow-devops/postgres-loader-pubsub-ce/google | 0.5.0 |
+| <a name="module_postgres_loader_enriched"></a> [postgres\_loader\_enriched](#module\_postgres\_loader\_enriched) | snowplow-devops/postgres-loader-pubsub-ce/google | 0.5.0 |
 | <a name="module_raw_topic"></a> [raw\_topic](#module\_raw\_topic) | snowplow-devops/pubsub-topic/google | 0.3.0 |
 
 ## Resources
@@ -55,11 +55,11 @@
 | <a name="input_bigquery_loader_dead_letter_bucket_deploy"></a> [bigquery\_loader\_dead\_letter\_bucket\_deploy](#input\_bigquery\_loader\_dead\_letter\_bucket\_deploy) | Whether this module should create a new bucket with the specified name - if the bucket already exists set this to false | `bool` | `true` | no |
 | <a name="input_bigquery_loader_dead_letter_bucket_name"></a> [bigquery\_loader\_dead\_letter\_bucket\_name](#input\_bigquery\_loader\_dead\_letter\_bucket\_name) | The name of the GCS bucket to use for dead-letter output of loader | `string` | `""` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | The labels to append to the resources in this module | `map(string)` | `{}` | no |
-| <a name="input_postgres_db_authorized_networks"></a> [postgres\_db\_authorized\_networks](#input\_postgres\_db\_authorized\_networks) | The list of CIDR ranges to allow access to the Pipeline Database over | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
+| <a name="input_postgres_db_authorized_networks"></a> [postgres\_db\_authorized\_networks](#input\_postgres\_db\_authorized\_networks) | The list of CIDR ranges to allow access to the Pipeline Database over | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_postgres_db_enabled"></a> [postgres\_db\_enabled](#input\_postgres\_db\_enabled) | Whether to enable loading into a Postgres Database | `bool` | `false` | no |
 | <a name="input_postgres_db_tier"></a> [postgres\_db\_tier](#input\_postgres\_db\_tier) | The instance type to assign to the deployed Cloud SQL instance | `string` | `"db-g1-small"` | no |
-| <a name="input_ssh_key_pairs"></a> [ssh\_key\_pairs](#input\_ssh\_key\_pairs) | The list of SSH key-pairs to add to the servers | <pre>list(object({<br>    user_name  = string<br>    public_key = string<br>  }))</pre> | `[]` | no |
-| <a name="input_ssl_information"></a> [ssl\_information](#input\_ssl\_information) | The ID of an Google Managed certificate to bind to the load balancer | <pre>object({<br>    enabled        = bool<br>    certificate_id = string<br>  })</pre> | <pre>{<br>  "certificate_id": "",<br>  "enabled": false<br>}</pre> | no |
+| <a name="input_ssh_key_pairs"></a> [ssh\_key\_pairs](#input\_ssh\_key\_pairs) | The list of SSH key-pairs to add to the servers | <pre>list(object({<br/>    user_name  = string<br/>    public_key = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_ssl_information"></a> [ssl\_information](#input\_ssl\_information) | The ID of an Google Managed certificate to bind to the load balancer | <pre>object({<br/>    enabled        = bool<br/>    certificate_id = string<br/>  })</pre> | <pre>{<br/>  "certificate_id": "",<br/>  "enabled": false<br/>}</pre> | no |
 | <a name="input_telemetry_enabled"></a> [telemetry\_enabled](#input\_telemetry\_enabled) | Whether or not to send telemetry information back to Snowplow Analytics Ltd | `bool` | `true` | no |
 | <a name="input_user_provided_id"></a> [user\_provided\_id](#input\_user\_provided\_id) | An optional unique identifier to identify the telemetry events emitted by this stack | `string` | `""` | no |
 

--- a/terraform/gcp/pipeline/default/main.tf
+++ b/terraform/gcp/pipeline/default/main.tf
@@ -46,11 +46,9 @@ module "enriched_topic" {
 # 2. Deploy Collector stack
 module "collector_pubsub" {
   source  = "snowplow-devops/collector-pubsub-ce/google"
-  version = "0.5.0"
+  version = "0.6.0"
 
   accept_limited_use_license = var.accept_limited_use_license
-
-  app_version = "3.3.0"
 
   name = "${var.prefix}-collector"
 
@@ -90,11 +88,9 @@ module "collector_lb" {
 # 3. Deploy Enrichment
 module "enrich_pubsub" {
   source  = "snowplow-devops/enrich-pubsub-ce/google"
-  version = "0.3.0"
+  version = "0.4.0"
 
   accept_limited_use_license = var.accept_limited_use_license
-
-  app_version = "5.2.0"
 
   name = "${var.prefix}-enrich"
 

--- a/terraform/gcp/pipeline/default/target_bigquery.tf
+++ b/terraform/gcp/pipeline/default/target_bigquery.tf
@@ -37,7 +37,7 @@ locals {
 
 module "bigquery_loader" {
   source  = "snowplow-devops/bigquery-loader-pubsub-ce/google"
-  version = "0.3.0"
+  version = "0.4.0"
 
   accept_limited_use_license = var.accept_limited_use_license
 

--- a/terraform/gcp/pipeline/default/target_postgres.tf
+++ b/terraform/gcp/pipeline/default/target_postgres.tf
@@ -1,6 +1,6 @@
 module "postgres_db" {
   source  = "snowplow-devops/cloud-sql/google"
-  version = "0.3.1"
+  version = "0.4.1"
 
   count = var.postgres_db_enabled ? 1 : 0
 
@@ -20,7 +20,7 @@ module "postgres_db" {
 
 module "postgres_loader_enriched" {
   source  = "snowplow-devops/postgres-loader-pubsub-ce/google"
-  version = "0.4.0"
+  version = "0.5.0"
 
   accept_limited_use_license = var.accept_limited_use_license
 
@@ -57,7 +57,7 @@ module "postgres_loader_enriched" {
 
 module "postgres_loader_bad" {
   source  = "snowplow-devops/postgres-loader-pubsub-ce/google"
-  version = "0.4.0"
+  version = "0.5.0"
 
   accept_limited_use_license = var.accept_limited_use_license
 

--- a/terraform/gcp/pipeline/default/versions.tf
+++ b/terraform/gcp/pipeline/default/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.90"
+      version = ">= 6"
     }
     random = {
       source  = "hashicorp/random"

--- a/terraform/gcp/pipeline/secure/README.md
+++ b/terraform/gcp/pipeline/secure/README.md
@@ -3,29 +3,29 @@
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0.0 |
-| <a name="requirement_google"></a> [google](#requirement\_google) | >= 3.90 |
+| <a name="requirement_google"></a> [google](#requirement\_google) | >= 6 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_google"></a> [google](#provider\_google) | >= 3.90 |
+| <a name="provider_google"></a> [google](#provider\_google) | 6.39.0 |
 
 ## Modules
 
 | Name | Source | Version |
 |------|--------|---------|
 | <a name="module_bad_1_topic"></a> [bad\_1\_topic](#module\_bad\_1\_topic) | snowplow-devops/pubsub-topic/google | 0.3.0 |
-| <a name="module_bigquery_loader"></a> [bigquery\_loader](#module\_bigquery\_loader) | snowplow-devops/bigquery-loader-pubsub-ce/google | 0.3.0 |
+| <a name="module_bigquery_loader"></a> [bigquery\_loader](#module\_bigquery\_loader) | snowplow-devops/bigquery-loader-pubsub-ce/google | 0.4.0 |
 | <a name="module_bq_bad_rows_topic"></a> [bq\_bad\_rows\_topic](#module\_bq\_bad\_rows\_topic) | snowplow-devops/pubsub-topic/google | 0.3.0 |
 | <a name="module_collector_lb"></a> [collector\_lb](#module\_collector\_lb) | snowplow-devops/lb/google | 0.3.0 |
-| <a name="module_collector_pubsub"></a> [collector\_pubsub](#module\_collector\_pubsub) | snowplow-devops/collector-pubsub-ce/google | 0.5.0 |
-| <a name="module_enrich_pubsub"></a> [enrich\_pubsub](#module\_enrich\_pubsub) | snowplow-devops/enrich-pubsub-ce/google | 0.3.0 |
+| <a name="module_collector_pubsub"></a> [collector\_pubsub](#module\_collector\_pubsub) | snowplow-devops/collector-pubsub-ce/google | 0.6.0 |
+| <a name="module_enrich_pubsub"></a> [enrich\_pubsub](#module\_enrich\_pubsub) | snowplow-devops/enrich-pubsub-ce/google | 0.4.0 |
 | <a name="module_enriched_topic"></a> [enriched\_topic](#module\_enriched\_topic) | snowplow-devops/pubsub-topic/google | 0.3.0 |
-| <a name="module_postgres_db"></a> [postgres\_db](#module\_postgres\_db) | snowplow-devops/cloud-sql/google | 0.3.0 |
-| <a name="module_postgres_loader_bad"></a> [postgres\_loader\_bad](#module\_postgres\_loader\_bad) | snowplow-devops/postgres-loader-pubsub-ce/google | 0.4.0 |
-| <a name="module_postgres_loader_enriched"></a> [postgres\_loader\_enriched](#module\_postgres\_loader\_enriched) | snowplow-devops/postgres-loader-pubsub-ce/google | 0.4.0 |
+| <a name="module_postgres_db"></a> [postgres\_db](#module\_postgres\_db) | snowplow-devops/cloud-sql/google | 0.4.1 |
+| <a name="module_postgres_loader_bad"></a> [postgres\_loader\_bad](#module\_postgres\_loader\_bad) | snowplow-devops/postgres-loader-pubsub-ce/google | 0.5.0 |
+| <a name="module_postgres_loader_enriched"></a> [postgres\_loader\_enriched](#module\_postgres\_loader\_enriched) | snowplow-devops/postgres-loader-pubsub-ce/google | 0.5.0 |
 | <a name="module_raw_topic"></a> [raw\_topic](#module\_raw\_topic) | snowplow-devops/pubsub-topic/google | 0.3.0 |
 
 ## Resources
@@ -55,11 +55,11 @@
 | <a name="input_bigquery_loader_dead_letter_bucket_deploy"></a> [bigquery\_loader\_dead\_letter\_bucket\_deploy](#input\_bigquery\_loader\_dead\_letter\_bucket\_deploy) | Whether this module should create a new bucket with the specified name - if the bucket already exists set this to false | `bool` | `true` | no |
 | <a name="input_bigquery_loader_dead_letter_bucket_name"></a> [bigquery\_loader\_dead\_letter\_bucket\_name](#input\_bigquery\_loader\_dead\_letter\_bucket\_name) | The name of the GCS bucket to use for dead-letter output of loader | `string` | `""` | no |
 | <a name="input_labels"></a> [labels](#input\_labels) | The labels to append to the resources in this module | `map(string)` | `{}` | no |
-| <a name="input_postgres_db_authorized_networks"></a> [postgres\_db\_authorized\_networks](#input\_postgres\_db\_authorized\_networks) | The list of CIDR ranges to allow access to the Pipeline Database over | <pre>list(object({<br>    name  = string<br>    value = string<br>  }))</pre> | `[]` | no |
+| <a name="input_postgres_db_authorized_networks"></a> [postgres\_db\_authorized\_networks](#input\_postgres\_db\_authorized\_networks) | The list of CIDR ranges to allow access to the Pipeline Database over | <pre>list(object({<br/>    name  = string<br/>    value = string<br/>  }))</pre> | `[]` | no |
 | <a name="input_postgres_db_enabled"></a> [postgres\_db\_enabled](#input\_postgres\_db\_enabled) | Whether to enable loading into a Postgres Database | `bool` | `false` | no |
 | <a name="input_postgres_db_tier"></a> [postgres\_db\_tier](#input\_postgres\_db\_tier) | The instance type to assign to the deployed Cloud SQL instance | `string` | `"db-g1-small"` | no |
-| <a name="input_ssh_key_pairs"></a> [ssh\_key\_pairs](#input\_ssh\_key\_pairs) | The list of SSH key-pairs to add to the servers | <pre>list(object({<br>    user_name  = string<br>    public_key = string<br>  }))</pre> | `[]` | no |
-| <a name="input_ssl_information"></a> [ssl\_information](#input\_ssl\_information) | The ID of an Google Managed certificate to bind to the load balancer | <pre>object({<br>    enabled        = bool<br>    certificate_id = string<br>  })</pre> | <pre>{<br>  "certificate_id": "",<br>  "enabled": false<br>}</pre> | no |
+| <a name="input_ssh_key_pairs"></a> [ssh\_key\_pairs](#input\_ssh\_key\_pairs) | The list of SSH key-pairs to add to the servers | <pre>list(object({<br/>    user_name  = string<br/>    public_key = string<br/>  }))</pre> | `[]` | no |
+| <a name="input_ssl_information"></a> [ssl\_information](#input\_ssl\_information) | The ID of an Google Managed certificate to bind to the load balancer | <pre>object({<br/>    enabled        = bool<br/>    certificate_id = string<br/>  })</pre> | <pre>{<br/>  "certificate_id": "",<br/>  "enabled": false<br/>}</pre> | no |
 | <a name="input_telemetry_enabled"></a> [telemetry\_enabled](#input\_telemetry\_enabled) | Whether or not to send telemetry information back to Snowplow Analytics Ltd | `bool` | `true` | no |
 | <a name="input_user_provided_id"></a> [user\_provided\_id](#input\_user\_provided\_id) | An optional unique identifier to identify the telemetry events emitted by this stack | `string` | `""` | no |
 

--- a/terraform/gcp/pipeline/secure/main.tf
+++ b/terraform/gcp/pipeline/secure/main.tf
@@ -46,11 +46,9 @@ module "enriched_topic" {
 # 2. Deploy Collector stack
 module "collector_pubsub" {
   source  = "snowplow-devops/collector-pubsub-ce/google"
-  version = "0.5.0"
+  version = "0.6.0"
 
   accept_limited_use_license = var.accept_limited_use_license
-
-  app_version = "3.3.0"
 
   name = "${var.prefix}-collector"
 
@@ -92,11 +90,9 @@ module "collector_lb" {
 # 3. Deploy Enrichment
 module "enrich_pubsub" {
   source  = "snowplow-devops/enrich-pubsub-ce/google"
-  version = "0.3.0"
+  version = "0.4.0"
 
   accept_limited_use_license = var.accept_limited_use_license
-
-  app_version = "5.2.0"
 
   name = "${var.prefix}-enrich"
 

--- a/terraform/gcp/pipeline/secure/target_bigquery.tf
+++ b/terraform/gcp/pipeline/secure/target_bigquery.tf
@@ -37,7 +37,7 @@ locals {
 
 module "bigquery_loader" {
   source  = "snowplow-devops/bigquery-loader-pubsub-ce/google"
-  version = "0.3.0"
+  version = "0.4.0"
 
   accept_limited_use_license = var.accept_limited_use_license
 

--- a/terraform/gcp/pipeline/secure/target_postgres.tf
+++ b/terraform/gcp/pipeline/secure/target_postgres.tf
@@ -1,6 +1,6 @@
 module "postgres_db" {
   source  = "snowplow-devops/cloud-sql/google"
-  version = "0.3.1"
+  version = "0.4.1"
 
   count = var.postgres_db_enabled ? 1 : 0
 
@@ -20,7 +20,7 @@ module "postgres_db" {
 
 module "postgres_loader_enriched" {
   source  = "snowplow-devops/postgres-loader-pubsub-ce/google"
-  version = "0.4.0"
+  version = "0.5.0"
 
   accept_limited_use_license = var.accept_limited_use_license
 
@@ -59,7 +59,7 @@ module "postgres_loader_enriched" {
 
 module "postgres_loader_bad" {
   source  = "snowplow-devops/postgres-loader-pubsub-ce/google"
-  version = "0.4.0"
+  version = "0.5.0"
 
   accept_limited_use_license = var.accept_limited_use_license
 

--- a/terraform/gcp/pipeline/secure/terraform.tfvars
+++ b/terraform/gcp/pipeline/secure/terraform.tfvars
@@ -1,5 +1,5 @@
 # Please accept the terms of the Snowplow Limited Use License Agreement to proceed. (https://docs.snowplow.io/limited-use-license-1.0/)
-accept_limited_use_license = false
+accept_limited_use_license = true
 
 # Will be prefixed to all resource names
 # Use this to easily identify the resources created and provide entropy for subsequent environments

--- a/terraform/gcp/pipeline/secure/versions.tf
+++ b/terraform/gcp/pipeline/secure/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = ">= 3.90"
+      version = ">= 6"
     }
     random = {
       source  = "hashicorp/random"


### PR DESCRIPTION
Updates all GCP modules to use Ubuntu 24.04 as their base image as 20.04 has been unpublished over the weekend by Google.

Also makes the following changes for GCP:

1. Cloud SQL uses Postgres 16 as default now instead of 9.6 which is no longer supported
2. Iglu Server v0.14.0
3. Collector v3.4.0
4. Enrich v5.3.0